### PR TITLE
eslint improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "babel-cli": "^6.6.5",
     "babel-eslint": "7.1.1",
     "babel-loader": "^6.2.4",
-    "babel-plugin-module-alias": "^1.2.0",
     "babel-plugin-module-resolver": "^2.4.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.16.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "examples:html": "npm run examples:files; pug --obj ./examples/files.json --watch ./examples/src/templates/*.pug --out ./examples",
     "examples:files": "pug --obj ./examples/files.json ./examples/src/templates/*.pug --out ./examples; node ./examples/files",
     "build": "npm run lint; babel src --out-dir lib",
-    "lint": "eslint --ext .js ./src --cache"
+    "lint": "eslint --fix --ext .js ./src --cache"
   },
   "author": "Amelie Rosser <mail@ixviii.co.uk> (https://www.ixviii.io)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "examples:html": "npm run examples:files; pug --obj ./examples/files.json --watch ./examples/src/templates/*.pug --out ./examples",
     "examples:files": "pug --obj ./examples/files.json ./examples/src/templates/*.pug --out ./examples; node ./examples/files",
     "build": "npm run lint; babel src --out-dir lib",
-    "lint": "eslint --fix --ext .js ./src --cache"
+    "lint": "eslint --ext .js ./src --cache"
   },
   "author": "Amelie Rosser <mail@ixviii.co.uk> (https://www.ixviii.io)",
   "license": "MIT",
@@ -55,6 +55,7 @@
     "rules": {
       "global-require": 0,
       "arrow-body-style": 0,
+      "class-methods-use-this": 0,
       "comma-dangle": 0,
       "indent": [
         1,

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "rules": {
       "global-require": 0,
       "arrow-body-style": 0,
+      "comma-dangle": 0,
       "indent": [
         1,
         "tab",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,10 @@
     "babel-preset-stage-0": "^6.16.0",
     "concurrently": "^3.1.0",
     "dat-gui": "^0.5.0",
-    "eslint": "3.14.1",
-    "eslint-config-airbnb": "14.0.0",
-    "eslint-import-resolver-babel-module": "^2.2.1",
-    "eslint-import-resolver-webpack": "0.8.1",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "3.0.2",
-    "eslint-plugin-react": "6.9.0",
+    "eslint": "3.15.0",
+    "eslint-config-airbnb-base": "11.1.0",
+    "eslint-import-resolver-babel-module": "3.0.0",
+    "eslint-plugin-import": "2.2.0",
     "live-server": "^1.2.0",
     "pug-cli": "^1.0.0-alpha6",
     "query-string": "^4.3.1",
@@ -41,7 +38,7 @@
   },
   "eslintConfig": {
     "parser": "babel-eslint",
-    "extends": "airbnb",
+    "extends": "airbnb-base/legacy",
     "settings": {
       "import/resolver": {
         "babel-module": {}
@@ -51,16 +48,9 @@
       "browser": true,
       "es6": true
     },
-    "plugins": [
-      "react",
-      "jsx-a11y"
-    ],
     "parserOptions": {
       "ecmaVersion": 6,
-      "sourceType": "module",
-      "ecmaFeatures": {
-        "jsx": true
-      }
+      "sourceType": "module"
     },
     "rules": {
       "global-require": 0,
@@ -81,15 +71,7 @@
       ],
       "no-param-reassign": 0,
       "no-shadow": 0,
-      "no-underscore-dangle": 0,
-      "react/jsx-indent-props": [
-        1,
-        "tab"
-      ],
-      "react/jsx-indent": [
-        1,
-        "tab"
-      ]
+      "no-underscore-dangle": 0
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
       ],
       "no-param-reassign": 0,
       "no-shadow": 0,
+      "no-tabs": 0,
       "no-underscore-dangle": 0
     }
   }


### PR DESCRIPTION
Hello,

Had a little look at your project setup and saw that you could strip back the Eslint setup. The one you had was setup for React projects. So converted it to use just the [`eslint-config-airbnb-base` ](https://github.com/airbnb/javascript/tree/eslint-config-airbnb-v14.1.0/packages/eslint-config-airbnb-base) preset.

I have disabled a few rules that l thought you don't need. Tried to commit often to make things clearer. There are a few lint errors still being caught but have left those alone.  Not sure you would want to disable those rules.

Also removed `babel-plugin-module-alias` as you also have `babel-plugin-module-resolver` which is the replacement for it.